### PR TITLE
'player' 역할이 없을 경우, 오류 메세지를 stderr로 출력하도록 수정함.

### DIFF
--- a/together_bot/role.py
+++ b/together_bot/role.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from typing import Dict
 
 import discord
@@ -19,7 +20,7 @@ class Role(commands.Cog):
         if role_player is not None:
             await member.add_roles(role_player)
         else:
-            print("Error: Role 'player' doesn't exist.")
+            print("Role 'player' doesn't exist.", file=sys.stderr)
 
     @commands.group()
     async def role(self, ctx):


### PR DESCRIPTION
나중에 logging 적용할 때, stderr 로 출력되는 걸 기준으로 오류 메세지들을 찾기 때문에, 이 오류 메세지를 빼먹을 가능성이 있음.