### PR TITLE
시간 관련 명령어 추가 & message.delete 관련 버그 수정

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -286,6 +286,17 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 category = "main"
+description = "Extensions to the standard Python datetime module"
+name = "python-dateutil"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+version = "2.8.1"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+category = "main"
 description = "Add .env support to your django/flask apps in development and deployments"
 name = "python-dotenv"
 optional = false
@@ -312,7 +323,7 @@ python-versions = "*"
 version = "2020.10.23"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
@@ -364,7 +375,7 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [metadata]
-content-hash = "278087e1a3c08ecc7e7a77bc40a66ff3cf5d3f7ee2241eb08e9026f5311eb626"
+content-hash = "fec65d8906ad93ae1c73d95717284228ded6b5e22f9a9a1df75040b4b57629d3"
 lock-version = "1.0"
 python-versions = "3.8.6"
 
@@ -509,6 +520,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
+    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
 python-dotenv = [
     {file = "python-dotenv-0.14.0.tar.gz", hash = "sha256:8c10c99a1b25d9a68058a1ad6f90381a62ba68230ca93966882a4dbc3bc9c33d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ python = "3.8.6"
 "discord.py" = "^1.5.1"
 python-dotenv = "^0.14.0"
 pyyaml = "^5.3.1"
+python-dateutil = "^2.8.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/together_bot/bot.py
+++ b/together_bot/bot.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 
 import together_bot.channel
 import together_bot.role
+import together_bot.time
 
 ROOT_DIR = Path(__file__).parent.parent
 CONFIG_PATH = os.path.join(ROOT_DIR, "logging.yml")
@@ -94,6 +95,7 @@ def start():
         setup(bot)
         together_bot.channel.setup(bot)
         together_bot.role.setup(bot)
+        together_bot.time.setup(bot)
         bot.run(DISCORD_BOT_TOKEN)
     else:
         logging.error("MUST NEED BOT TOKEN")

--- a/together_bot/role.py
+++ b/together_bot/role.py
@@ -46,7 +46,7 @@ class Role(commands.Cog):
     async def role(self, ctx):
         if ctx.invoked_subcommand is None:
             await ctx.send("Need subcommand", delete_after=15.0)
-            await ctx.message.delete(delete_after=15.0)
+            await ctx.message.delete(delay=15.0)
 
     @role.command(brief="특정 역할에 참가함.", help="name에 참가할 역할 이름을 입력함.")
     async def get(self, ctx, name: str, duration: Optional[str]):

--- a/together_bot/time.py
+++ b/together_bot/time.py
@@ -18,7 +18,7 @@ class Time(commands.Cog):
     async def time(self, ctx):
         if ctx.invoked_subcommand is None:
             await ctx.send("Need subcommand", delete_after=15.0)
-            await ctx.message.delete(delete_after=15.0)
+            await ctx.message.delete(delay=15.0)
 
     @time.command(brief="현재 시간을 UTC와 PST로 보여줌.")
     async def now(self, ctx):

--- a/together_bot/time.py
+++ b/together_bot/time.py
@@ -1,0 +1,49 @@
+import logging
+import asyncio
+from datetime import datetime, timezone, timedelta
+from dateutil.parser import parse
+
+import discord
+from discord.ext import commands
+
+tz_pst = timezone(-timedelta(hours=8))
+tz_local = datetime.now(timezone.utc).astimezone().tzinfo
+
+
+class Time(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.group(brief="시간 관련 명령어 모음")
+    async def time(self, ctx):
+        if ctx.invoked_subcommand is None:
+            await ctx.send("Need subcommand", delete_after=15.0)
+            await ctx.message.delete(delete_after=15.0)
+
+    @time.command(brief="현재 시간을 UTC와 PST로 보여줌.")
+    async def now(self, ctx):
+        dt = datetime.now(timezone.utc)
+        await ctx.send(
+            f"utc: {dt.isoformat(' ', 'seconds')}\npst: {dt.astimezone(tz_pst).isoformat(' ', 'seconds')}"
+        )
+
+    @time.command(
+        brief="입력된 시간을 UTC와 PST로 변환해서 보여줌.",
+        help="local_time에 변환할 한국 기준 시간을 입력(ex.2020-11-30 09:59PM)",
+    )
+    async def convert(self, ctx, *, local_time: str):
+        try:
+            dt = parse(local_time).astimezone(tz_local)
+            await ctx.send(
+                f"utc: {dt.astimezone(timezone.utc).isoformat(' ', 'seconds')}\npst: {dt.astimezone(tz_pst).isoformat(' ', 'seconds')}"
+            )
+        except ValueError:
+            logging.error("unknown string format: " + local_time)
+            await ctx.send("unknown string format")
+        except OverflowError:
+            logging.error("date is too large")
+            await ctx.send("date is too large")
+
+
+def setup(bot):
+    bot.add_cog(Time(bot))

--- a/together_bot/time.py
+++ b/together_bot/time.py
@@ -7,7 +7,7 @@ import discord
 from discord.ext import commands
 
 tz_pst = timezone(-timedelta(hours=8))
-tz_local = datetime.now(timezone.utc).astimezone().tzinfo
+tz_kst = timezone(timedelta(hours=9))
 
 
 class Time(commands.Cog):
@@ -24,21 +24,21 @@ class Time(commands.Cog):
     async def now(self, ctx):
         dt = datetime.now(timezone.utc)
         await ctx.send(
-            f"utc: {dt.isoformat(' ', 'seconds')}\npst: {dt.astimezone(tz_pst).isoformat(' ', 'seconds')}"
+            f"UTC: {dt.isoformat(' ', 'seconds')}\nPST: {dt.astimezone(tz_pst).isoformat(' ', 'seconds')}"
         )
 
     @time.command(
-        brief="입력된 시간을 UTC와 PST로 변환해서 보여줌.",
-        help="local_time에 변환할 한국 기준 시간을 입력(ex.2020-11-30 09:59PM)",
+        brief="입력된 한국 시간을 UTC와 PST로 변환해서 보여줌.",
+        help="kst_time에 변환할 한국 기준 시간을 입력(ex.2020-11-30 09:59PM)",
     )
-    async def convert(self, ctx, *, local_time: str):
+    async def convert(self, ctx, *, kst_time: str):
         try:
-            dt = parse(local_time).astimezone(tz_local)
+            dt = parse(kst_time).astimezone(tz_kst)
             await ctx.send(
-                f"utc: {dt.astimezone(timezone.utc).isoformat(' ', 'seconds')}\npst: {dt.astimezone(tz_pst).isoformat(' ', 'seconds')}"
+                f"UTC: {dt.astimezone(timezone.utc).isoformat(' ', 'seconds')}\nPST: {dt.astimezone(tz_pst).isoformat(' ', 'seconds')}"
             )
         except ValueError:
-            logging.error("unknown string format: " + local_time)
+            logging.error("unknown string format: " + kst_time)
             await ctx.send("unknown string format")
         except OverflowError:
             logging.error("date is too large")


### PR DESCRIPTION
시간 관련 명령어 추가
- time now: 현재 시간을 UTC와 PST로 출력함.
- time convert <local_time>: 입력된 시간을 UTC와 PST로 변환해줌.

ctx.message.delete에 delete_after라는 인자를 찾지 못하는 버그 수정
- delay를 delete_after로 잘못 적음.