### PR TITLE
time 명령어의 test 추가

### DIFF
--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from together_bot.time import (
+    from_kst_time_string,
+    from_utc_timestamp,
+    to_pst_time_format,
+    to_utc_time_format,
+    tz_kst,
+)
+
+kst_time_data = datetime(2020, 11, 30, 21, 59, tzinfo=tz_kst)
+utc_time_data = datetime(2020, 11, 30, 21, 59, tzinfo=timezone.utc)
+
+
+def test_from_utc_timestamp():
+    assert from_utc_timestamp(int(1620750422.7079058)) == datetime(
+        2021, 5, 11, 16, 27, 2, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.parametrize(
+    "format_test_data, expected",
+    [
+        (kst_time_data, "2020-11-30 12:59:00+00:00"),
+        (utc_time_data, "2020-11-30 21:59:00+00:00"),
+    ],
+)
+def test_to_utc_time_format(format_test_data, expected):
+    assert to_utc_time_format(format_test_data) == expected
+
+
+@pytest.mark.parametrize(
+    "format_test_data, expected",
+    [
+        (kst_time_data, "2020-11-30 04:59:00-08:00"),
+        (utc_time_data, "2020-11-30 13:59:00-08:00"),
+    ],
+)
+def test_to_pst_time_format(format_test_data, expected):
+    assert to_pst_time_format(format_test_data) == expected
+
+
+def test_from_kst_time_string():
+    assert from_kst_time_string("2020-11-30 09:59PM") == datetime(
+        2020, 11, 30, 21, 59, tzinfo=tz_kst
+    )
+
+
+# timezone 정보가 있더라도 입력값은 무조건 KST이라고 간주함.
+def test_from_kst_time_string_with_ignoretz():
+    assert from_kst_time_string("2021-03-31 17:17:01+00:00") == datetime(
+        2021, 3, 31, 17, 17, 1, tzinfo=tz_kst
+    )

--- a/together_bot/time.py
+++ b/together_bot/time.py
@@ -43,8 +43,7 @@ class Time(commands.Cog):
         try:
             dt = from_kst_time_string(kst_time)
             await ctx.send(
-                f"UTC: {to_utc_time_format(dt)}\n"
-                + f"PST: {to_pst_time_format(dt)}"
+                f"UTC: {to_utc_time_format(dt)}\n" + f"PST: {to_pst_time_format(dt)}"
             )
         except ValueError:
             logging.error("unknown string format: " + kst_time)
@@ -59,11 +58,11 @@ def from_utc_timestamp(timestamp: int) -> datetime:
 
 
 def to_utc_time_format(dt: datetime) -> str:
-    return dt.astimezone(timezone.utc).isoformat(' ', 'seconds')
+    return dt.astimezone(timezone.utc).isoformat(" ", "seconds")
 
 
 def to_pst_time_format(dt: datetime) -> str:
-    return dt.astimezone(tz_pst).isoformat(' ', 'seconds')
+    return dt.astimezone(tz_pst).isoformat(" ", "seconds")
 
 
 def from_kst_time_string(kst_time: str):


### PR DESCRIPTION
test 목록
 * timestamp 값을 UTC 시간대의 datetime으로 변환
 * UTC 또는 KST 시각을 UTC 시각으로 출력
 * UTC 또는 KST 시각을 PST 시각으로 출력
 * 문자열로 된 시각을 KST 시간대의 datetime으로 변환
 * 문자열로 된 시각에 timezone이 포함되어 있더라도 무시하고 KST 시간대의
 datetime으로 변환