### PR TITLE
Check dependecies weekly and fixate version of dependencies from github action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,20 @@
 version: 2
 updates:
-#
+  # Python dependencies check
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     allow:
       - dependency-type: "production"
-# Set update schedule for GitHub Actions
+  # for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every weekday
-      interval: "daily"
+      interval: "weekly"
+    ignore:
+      - dependency-name: "actions/checkout"
+        versions: ["2.x"]
+      - dependency-name: "actions/setup-python"
+        versions: ["2.x"]


### PR DESCRIPTION
# 목적
버그가 포함된 배포가 즉시 적용되는 상황을 줄이고, 의존성 확인 주기를 늘려서 알림 빈도를 줄임.

# 적용사항
1. 의존성 확인을 daily에서 weekly로 변경
2. github action 관련된 종속은 현재 버전을 고정하고, major 버전 업데이트에 한해서 PR을 생성하도록 변경

## 2번 적용사항에 대한 추가 설명
checkout@v2와 setup-python@v2 은 v2.x.x 버전의 업데이트를 따라간다. 따라서 dependabot도 v2에 대한 모든 업데이트를 생성하는데, 이 부분을 2번 적용사항에 나온 대로 수정한다.

1. `ignore` 옵션을 추가해서 2.x에 대한 minor 버전 업데이트 무시
2. dependabot PR에 `@dependabot ignore this major version` 코멘트 추가 (#59)

3.x 이후 major 버전 업데이트부터는 2번 방법으로만 진행한다.