### PR TITLE
Time 명령어 경계값 관련 테스트 추가 #63

### DIFF
--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -80,7 +80,7 @@ def test_kst_time_wrong_date(kst_time):
     ],
 )
 def test_kst_time_overflow_by_timezone_change(kst_time):
-    with pytest.raises(OSError):
+    with pytest.raises(OverflowError):
         dt = from_kst_time_string(kst_time)
         dt.astimezone(timezone(timedelta(hours=8)))  # KST-1
         dt.astimezone(timezone(timedelta(hours=10)))  # KST+1
@@ -105,17 +105,3 @@ def test_kst_time_invalid_arguments(kst_time, expected_error):
 def test_timestamp_overflow(timestamp):
     with pytest.raises(OverflowError):
         print(from_utc_timestamp(timestamp))
-
-
-# issue 63 참조
-@pytest.mark.parametrize(
-    "timestamp",
-    [
-        2 ** 60,
-        -43201,
-        1523443804214.0,
-    ],
-)
-def test_wrong_timestamp(timestamp):
-    with pytest.raises(OSError):
-        from_utc_timestamp(timestamp)

--- a/together_bot/time.py
+++ b/together_bot/time.py
@@ -58,7 +58,7 @@ class Time(commands.Cog):
             logging.error("unknown string format: " + kst_time)
             await ctx.send("unknown string format")
         except TypeError:
-            logging.error("wrong type: " + type(kst_time))
+            logging.error("wrong type: " + str(type(kst_time)))
             await ctx.send("unknown string format")
         except OSError:
             logging.error("changing timezone failed")
@@ -80,7 +80,7 @@ def to_pst_time_format(dt: datetime) -> str:
     return dt.astimezone(tz_pst).isoformat(" ", "seconds")
 
 
-def from_kst_time_string(kst_time: str):
+def from_kst_time_string(kst_time: str) -> datetime:
     return parse(kst_time, ignoretz=True).replace(tzinfo=tz_kst)
 
 

--- a/together_bot/time.py
+++ b/together_bot/time.py
@@ -81,7 +81,7 @@ def to_pst_time_format(dt: datetime) -> str:
 
 
 def from_kst_time_string(kst_time: str):
-    return parse(kst_time, ignoretz=True).astimezone(tz_kst)
+    return parse(kst_time, ignoretz=True).replace(tzinfo=tz_kst)
 
 
 def setup(bot: commands.Bot):

--- a/together_bot/time.py
+++ b/together_bot/time.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 import ntplib
-from dateutil.parser import parse
+from dateutil.parser import ParserError, parse
 from discord.ext import commands
 
 tz_pst = timezone(-timedelta(hours=8))
@@ -34,6 +34,12 @@ class Time(commands.Cog):
         except ntplib.NTPException:
             logging.error("NTP server doesn't respond")
             await ctx.send("NTP 서버에 연결할 수 없습니다. 나중에 다시 시도해주세요.")
+        except OverflowError:
+            logging.error("Timestamp overflow")
+            await ctx.send("잠시 후 다시 시도해주세요.")
+        except OSError:
+            logging.error("OS can't recognize timestamp")
+            await ctx.send("잠시 후 다시 시도해주세요.")
 
     @time.command(
         brief="입력된 한국 시간을 UTC와 PST로 변환해서 보여줌.",
@@ -48,6 +54,15 @@ class Time(commands.Cog):
         except ValueError:
             logging.error("unknown string format: " + kst_time)
             await ctx.send("unknown string format")
+        except ParserError:
+            logging.error("unknown string format: " + kst_time)
+            await ctx.send("unknown string format")
+        except TypeError:
+            logging.error("wrong type: " + type(kst_time))
+            await ctx.send("unknown string format")
+        except OSError:
+            logging.error("changing timezone failed")
+            await ctx.send("convert failed")
         except OverflowError:
             logging.error("date is too large")
             await ctx.send("date is too large")


### PR DESCRIPTION
- `dateutil.parser`를 사용하는 함수에 대한 예외 처리 추가
    - `ValueError`, `OSError`, `OverflowError`, `TypeError`,
    `ParserError`
- `datetime.fromtimestamp()`를 사용하는 함수에 대한 예외 처리 추가
    - `OverflowError`, `OSError`