### PR TITLE
Github Actions이 Draft PR은 무시함.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,14 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+    push:
+    pull_request:
+      types: [ opened, reopened, synchronize, ready_for_review ]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2.2.2


### PR DESCRIPTION
github lint action이 draft pr에는 실행되지 않도록 변경 #71

pull request에 다음 이벤트가 발생했을 때 작동함.
1. 새로 열었을 때.
2. 다시 열었을 때.
3. PR 브랜치에 새로운 커밋이 들어왔을 때.
4. draft PR을 review 가능으로 바꿨을 때.

단, draft PR이 아닐 때만 작동함.