### PR TITLE
비속어 메세지를 검열하지 않고 포함된 비속어 목록을 답장하도록 변경

### DIFF
--- a/tests/test_fword.py
+++ b/tests/test_fword.py
@@ -1,6 +1,12 @@
 import pytest
 
-from together_bot.fword import FWORD_LIST_PATH, Trie, TrieNode, summarize_fwords
+from together_bot.fword import (
+    FWORD_LIST_PATH,
+    Trie,
+    TrieNode,
+    summarize_fwords,
+    to_fwords_set,
+)
 
 
 # Helper function
@@ -276,9 +282,30 @@ def test_ignore_incorrect_but_found_first(trie):
 
 
 # 2. fword 명령어 관련 테스트
-# 2.a. summarize_fwords() 테스트
+# 2.a. to_fwords_set() 테스트
+def test_occurrences_to_fwords():
+    # given
+    origin = "안녕 그리고 안녕"
+    occurrences = [range(3, 6)]
+    # when
+    actual = to_fwords_set(origin, occurrences)
+    # then
+    expected = set(["그리고"])
+    assert actual == expected
 
 
+def test_fwords_without_duplicated():
+    # given
+    origin = "안녕 그리고 안녕"
+    occurrences = [range(0, 2), range(7, 9)]
+    # when
+    actual = to_fwords_set(origin, occurrences)
+    # then
+    expected = set(["안녕"])
+    assert actual == expected
+
+
+# 2.b. summarize_fwords() 테스트
 def test_empty_summary():
     # given
     detected_fwords = None

--- a/tests/test_fword.py
+++ b/tests/test_fword.py
@@ -1,6 +1,6 @@
 import pytest
 
-from together_bot.fword import FWORD_LIST_PATH, Trie, TrieNode, censor
+from together_bot.fword import FWORD_LIST_PATH, Trie, TrieNode, summarize_fwords
 
 
 # Helper function
@@ -276,50 +276,48 @@ def test_ignore_incorrect_but_found_first(trie):
 
 
 # 2. fword 명령어 관련 테스트
-# 2.a. censor 테스트
+# 2.a. summarize_fwords() 테스트
 
 
-def test_censor_empty_bounds():
+def test_empty_summary():
     # given
-    message = "hello"
-    bounds = []
+    detected_fwords = None
     # when
-    actual = censor(message, bounds)
+    actual = summarize_fwords(detected_fwords)
     # then
-    expected = "hello"
+    expected = "없음"
     assert actual == expected
 
 
-def test_censor_bounds_only_stop():
+def test_empty_summary2():
     # given
-    message = "hello"
-    bounds = [range(2)]
+    detected_fwords = []
     # when
-    actual = censor(message, bounds)
+    actual = summarize_fwords(detected_fwords)
     # then
-    expected = "||he||llo"
+    expected = "없음"
     assert actual == expected
 
 
-def test_censor_bounds_out_range():
+def test_summary_less_or_equal_max_represent():
     # given
-    message = "hello"
-    bounds = [range(-5, -2), range(-1, 3), range(4, 6), range(7, 12)]
+    max_represent = 3
+    detected_fwords = ["하나", "둘"]
     # when
-    actual = censor(message, bounds)
+    actual = summarize_fwords(detected_fwords, max_represent)
     # then
-    expected = "hello"
+    expected = "하나, 둘"
     assert actual == expected
 
 
-def test_censor():
+def test_summary_over_max_represent():
     # given
-    message = "hello"
-    bounds = [range(1, 3)]
+    max_represent = 3
+    detected_fwords = ["하나", "둘", "셋", "넷"]
     # when
-    actual = censor(message, bounds)
+    actual = summarize_fwords(detected_fwords, max_represent)
     # then
-    expected = "h||el||lo"
+    expected = "하나, 둘, 셋 외 1개"
     assert actual == expected
 
 

--- a/tests/test_fword.py
+++ b/tests/test_fword.py
@@ -4,8 +4,8 @@ from together_bot.fword import (
     FWORD_LIST_PATH,
     Trie,
     TrieNode,
+    get_detected_fwords,
     summarize_fwords,
-    to_fwords_set,
 )
 
 
@@ -282,13 +282,13 @@ def test_ignore_incorrect_but_found_first(trie):
 
 
 # 2. fword 명령어 관련 테스트
-# 2.a. to_fwords_set() 테스트
+# 2.a. get_detected_fwords() 테스트
 def test_occurrences_to_fwords():
     # given
     origin = "안녕 그리고 안녕"
     occurrences = [range(3, 6)]
     # when
-    actual = to_fwords_set(origin, occurrences)
+    actual = get_detected_fwords(origin, occurrences)
     # then
     expected = set(["그리고"])
     assert actual == expected
@@ -299,7 +299,7 @@ def test_fwords_without_duplicated():
     origin = "안녕 그리고 안녕"
     occurrences = [range(0, 2), range(7, 9)]
     # when
-    actual = to_fwords_set(origin, occurrences)
+    actual = get_detected_fwords(origin, occurrences)
     # then
     expected = set(["안녕"])
     assert actual == expected

--- a/together_bot/fword.py
+++ b/together_bot/fword.py
@@ -78,7 +78,7 @@ class Fword(commands.Cog):
                 return
 
             # 중복된 비속어는 한번만 출력해야 함.
-            detected_fwords = to_fwords_set(origin, occurrences)
+            detected_fwords = get_detected_fwords(origin, occurrences)
             logging.info(
                 f'fword detect - {message.author.id}: {", ".join(detected_fwords)}'
             )
@@ -100,7 +100,7 @@ class Fword(commands.Cog):
         logging.info(f"fword user count: {len(self.user_ids)}")
 
 
-def to_fwords_set(origin: str, occurrences: list[range]) -> set[str]:
+def get_detected_fwords(origin: str, occurrences: list[range]) -> set[str]:
     return set(map(lambda r: origin[r.start : r.stop], occurrences))
 
 

--- a/together_bot/fword.py
+++ b/together_bot/fword.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import csv
 import logging
 import time
+from itertools import islice
 from pathlib import Path
-from typing import Iterable
 
 import discord
 from discord.ext import commands
@@ -76,9 +76,16 @@ class Fword(commands.Cog):
             occurrences = self.search_tree.find_all_occurrences(origin)
             if len(occurrences) == 0:
                 return
-            censored = censor(origin, occurrences)
-            await message.delete()
-            await message.channel.send(f"{message.author.display_name}: {censored}")
+
+            # 중복된 비속어는 한번만 출력해야 함.
+            detected_fwords = set(map(lambda r: origin[r.start : r.stop], occurrences))
+            logging.info(
+                f'fword detect - {message.author.id}: {", ".join(detected_fwords)}'
+            )
+
+            await message.reply(
+                "비속어 감지 - " + summarize_fwords(detected_fwords), mention_author=False
+            )
 
     def __init_search_tree(self, file_path: str):
         timestamp_load_begin = time.process_time()
@@ -93,16 +100,17 @@ class Fword(commands.Cog):
         logging.info(f"fword user count: {len(self.user_ids)}")
 
 
-def censor(content: str, bounds: Iterable[range]) -> str:
-    char_list = [*content]
-    for bound in bounds:
-        start = bound.start
-        stop = bound.stop
-        if 0 <= start < stop <= len(content):
-            char_list[start] = "||" + char_list[start]
-            char_list[stop - 1] = char_list[stop - 1] + "||"
+# 감지된 비속어 목록을 요약된 문자열로 표현함.
+def summarize_fwords(detected_fwords: set[str], max_represent=3) -> str:
+    if detected_fwords is None or len(detected_fwords) == 0:
+        return "없음"
 
-    return "".join(char_list)
+    # 개수가 max_represent 보다 많으면 "xxx 외 n개"로 표현한다.
+    return ", ".join(islice(detected_fwords, max_represent)) + (
+        f" 외 {len(detected_fwords)-max_represent}개"
+        if len(detected_fwords) > max_represent
+        else ""
+    )
 
 
 def setup(bot: commands.Bot):

--- a/together_bot/fword.py
+++ b/together_bot/fword.py
@@ -78,7 +78,7 @@ class Fword(commands.Cog):
                 return
 
             # 중복된 비속어는 한번만 출력해야 함.
-            detected_fwords = set(map(lambda r: origin[r.start : r.stop], occurrences))
+            detected_fwords = to_fwords_set(origin, occurrences)
             logging.info(
                 f'fword detect - {message.author.id}: {", ".join(detected_fwords)}'
             )
@@ -98,6 +98,10 @@ class Fword(commands.Cog):
             for (user_id,) in session.query(fword_user.FwordUser.discord_id):
                 self.user_ids.add(user_id)
         logging.info(f"fword user count: {len(self.user_ids)}")
+
+
+def to_fwords_set(origin: str, occurrences: list[range]) -> set[str]:
+    return set(map(lambda r: origin[r.start : r.stop], occurrences))
 
 
 # 감지된 비속어 목록을 요약된 문자열로 표현함.


### PR DESCRIPTION
 ### 변경 사유

디코에서 써보니까 봇이 수정할 수 없는 메세지로 바꿔서 불편함. 특히 비속어를 잘못 판단했을 때 수정 불가를 강제하는 건 잘못된 UI/UX라 생각해서 변경함.

### 관련 이슈

#82 #88 : 이 PR이 통과되면 더 이상 봇이 메세지를 덮어씌우지 않기 때문에 해결할 필요 없는 이슈

### 변경 사항

![변경 전](https://user-images.githubusercontent.com/7982279/141034972-27acc793-c617-4d86-9959-22344f13e74b.png)

변경 전: 비속어가 포함된 메세지를 제거하고 봇이 비속어를 가린 새 메세지를 올림.

![변경 후](https://user-images.githubusercontent.com/7982279/140949333-93270dc6-b327-45bc-8362-173cc894ce1f.png)

변경 후: 메세지에 포함된 비속어를 봇이 답장 형식으로 추가함.

--------------------------------------------------------------

- censor() 함수와 관련 단위 테스트들을 제거함: 변경 후에는 더 이상 사용하지 않는 함수가 됨.
- summarize_fwords() 추가 및 관련 테스트 추가: 변경 사항을 위해 추가된 함수.

답장으로 출력되는 비속어 목록은 다음 규칙을 따름
 - 중복을 허용 하지 않음.
 - 지정된 개수(3개)를 초과하면 "xxx 외 n개" 로 표시함.