### PR TITLE
abuse, adult, alba, anal, ass 제외

### DIFF
--- a/fword_list.csv
+++ b/fword_list.csv
@@ -94,9 +94,7 @@
 910임
 99bb
 ^노^
-abuse
 ac발
-adult
 adulthumor
 adultlife
 adultmana
@@ -104,13 +102,10 @@ adultsearch
 adultvideo
 adultzon
 adultzone
-alba
-anal
 apfhd
 aquaball
 arb구함
 asiangirl
-ass
 asshole
 av갤러리
 av배우

--- a/tests/test_fword.py
+++ b/tests/test_fword.py
@@ -401,3 +401,12 @@ def test_PR91(non_fword):
     actual = real_trie.find_all_occurrences(non_fword)
     # then
     assert len(actual) == 0
+
+
+@pytest.mark.parametrize("non_fword", ["analog", "assert", "albamon", "adult", "abuse"])
+def test_PR98(non_fword):
+    # given
+    # when
+    actual = real_trie.find_all_occurrences(non_fword)
+    # then
+    assert len(actual) == 0


### PR DESCRIPTION
- alba: 비속어라고 판단할 근거가 부족함.
- abuse, adult, anal, ass: 다른 단어랑 조합될 때만 비속어가 됨.