### PR TITLE
Update poetry installer script in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.9
 
 # Install poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-ENV PATH="/root/.poetry/bin:${PATH}"
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -
+ENV PATH="/root/.local/bin:${PATH}"
 RUN poetry config virtualenvs.create false
 
 # Install dependencies


### PR DESCRIPTION
Poetry 설치 스크립트가 변경되었고, 현재 사용하고 있는 `get-poetry.py` 는 다음 버전인 1.2부터 사용되지 않을 예정.

따라서 설치 스크립트 변경.