### PR TITLE
던파 오늘의 등급 갱신 시간 0시 1분으로 변경

### DIFF
--- a/together_bot/dnf.py
+++ b/together_bot/dnf.py
@@ -56,7 +56,7 @@ class Dnf(commands.Cog):
         logging.debug("DNF loop_call_grade called")
         # KST 0시 0분에 등급을 알려줌.
         current = datetime.datetime.utcnow()
-        if not (current.hour == 15 and current.minute == 0):
+        if not (current.hour == 15 and current.minute == 1):
             return
 
         hasSent = await self.__try_send_grade()


### PR DESCRIPTION
던파 서버가 0시 0분에 바로 갱신이 안되서 수정함.