### PR TITLE
던파 오늘의 등급 알림 채널을 DB에 저장하도록 수정

### DIFF
--- a/together_bot/dnf.py
+++ b/together_bot/dnf.py
@@ -6,6 +6,10 @@ import os
 import aiohttp
 import discord
 from discord.ext import commands, tasks
+from psycopg2 import IntegrityError
+
+from together_bot.models import dnf_grade_channel
+from together_bot.utils.db_toolkit import Session
 
 _DNF_API_BASE = "https://api.neople.co.kr/df"
 
@@ -15,7 +19,9 @@ _APP_ID = os.getenv("DNF_API_KEY")
 class Dnf(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot: commands.Bot = bot
-        self.channel: discord.TextChannel = None
+        self.channels: set[discord.TextChannel] = set()
+        self.today_grade = None
+        self.last_etag = None
         self.loop_call_grade.start()
 
     def cog_unload(self):
@@ -30,44 +36,70 @@ class Dnf(commands.Cog):
 
     @dnf.command(brief="오늘의 등급 알림 등록")
     async def sub(self, ctx: commands.Context):
-        self.channel = ctx.channel
-        message = f"던파 오늘의 등급 알림을 이 채널에 추가함. {self.channel.name}"
+        channel: discord.TextChannel = ctx.channel
+        if channel in self.channels:
+            logging.debug("이미 등록된 채널")
+            return
+
+        try:
+            with Session() as session:
+                dnf_grade_channel.save(session, channel.id)
+                session.commit()
+        except IntegrityError as e:
+            if "UNIQUE constraint failed: " not in repr(e):
+                raise
+        self.channels.add(channel)
+
+        message = f"던파 오늘의 등급 알림을 이 채널에 추가함. {channel.name}"
         logging.info(message)
         await ctx.send(message)
 
     @dnf.command(brief="오늘의 등급 알림 등록 해제")
     async def unsub(self, ctx: commands.Context):
-        if self.channel is None:
+        channel: discord.TextChannel = ctx.channel
+        if channel not in self.channels:
+            logging.debug("등록되지 않은 채널")
             return
-        self.channel = None
+
+        with Session() as session:
+            channel_in_db = dnf_grade_channel.find_by_discord_id(session, channel.id)
+            if channel_in_db is not None:
+                session.delete(channel_in_db)
+                session.commit()
+        self.channels.discard(channel)
+
         message = "던파 오늘의 등급 알림을 제거함."
         logging.info(message)
         await ctx.send(message)
 
     @dnf.command(brief="오늘의 등급 확인 (등록된 채널로 메세지가 전송됨)")
     async def grade(self, ctx: commands.Context):
-        if self.channel is None:
-            return
+        await self.__send_grade(ctx.channel)
 
-        await self.__try_send_grade()
+    async def __send_grade(self, channel: discord.TextChannel):
+        await channel.send(
+            "던파 오늘의 등급: " + self.today_grade
+            if self.today_grade is not None
+            else "갱신되지 않음."
+        )
 
     @tasks.loop(seconds=10)
     async def loop_call_grade(self):
         logging.debug("DNF loop_call_grade called")
         # KST 0시 0분에 등급을 알려줌.
         current = datetime.datetime.utcnow()
-        if not (current.hour == 15 and current.minute == 1):
+        if not (current.hour == 15 and current.minute == 0):
             return
 
-        hasSent = await self.__try_send_grade()
-        if hasSent:
-            await asyncio.sleep(60.0)
+        updated = await self.__try_update_grade()
+        if not updated:
+            return
 
-    async def __try_send_grade(self):
-        if self.channel is None:
-            return False
+        for channel in self.channels:
+            await self.__send_grade(channel)
+        await asyncio.sleep(60.0)
 
-        is_status_ok = False
+    async def __try_update_grade(self):
         url = (
             _DNF_API_BASE
             + "/items/ff3bdb021bcf73864005e78316dd961c/shop?apikey="
@@ -80,15 +112,16 @@ class Dnf(commands.Cog):
                 async with session.get(url) as response:
                     logging.info("DnF API status : {}".format(response.status))
                     if response.status == 200:
-                        is_status_ok = True
+                        etag = response.headers["etag"]
+                        logging.debug("dnf etag: " + etag)
+                        if etag == self.last_etag:
+                            return False
+
                         content = await response.json()
-                        grade = content["itemGradeName"]
-                        message = "던파 오늘의 등급: " + grade
-                        await self.channel.send(message)
+                        self.last_etag = etag
+                        self.today_grade = content["itemGradeName"]
                         return True
                 await asyncio.sleep(RETRY_DELAY)
-        if not is_status_ok:
-            await self.channel.send("오늘의 등급: 불러오기 실패")
 
         return False
 
@@ -96,10 +129,26 @@ class Dnf(commands.Cog):
     async def before_get_today_grade(self):
         logging.info("DNF scheduler: wait for bot ready")
         await self.bot.wait_until_ready()
+        self.__load_channels()
+        # 0시 0분과 1분 사이에 등급이 던파 서버에서 갱신되기 직전에 봇이 재시작해버리면
+        # 봇이 전날 등급이 최신인줄 알고 알릴 수 있으므로, 루프 전에 etag를 초기화함.
+        await self.__try_update_grade()
 
     @loop_call_grade.after_loop
     async def after_get_today_grade(self):
         logging.info("DNF scheduler: stop loop")
+
+    def __load_channels(self):
+        if self.bot is None:
+            return
+
+        with Session() as session:
+            for (channel_id,) in session.query(
+                dnf_grade_channel.DnfGradeChannel.discord_id
+            ):
+                new_channel = self.bot.get_channel(channel_id)
+                self.channels.add(new_channel)
+        logging.info(f"dnf subscribed channel count: {len(self.channels)}")
 
 
 def setup(bot: commands.Bot):

--- a/together_bot/dnf.py
+++ b/together_bot/dnf.py
@@ -77,11 +77,8 @@ class Dnf(commands.Cog):
         await self.__send_grade(ctx.channel)
 
     async def __send_grade(self, channel: discord.TextChannel):
-        await channel.send(
-            "던파 오늘의 등급: " + self.today_grade
-            if self.today_grade is not None
-            else "갱신되지 않음."
-        )
+        grade_text = self.today_grade if self.today_grade is not None else "갱신되지 않음."
+        await channel.send(f"던파 오늘의 등급: {grade_text}")
 
     @tasks.loop(seconds=10)
     async def loop_call_grade(self):
@@ -110,7 +107,7 @@ class Dnf(commands.Cog):
         async with aiohttp.ClientSession() as session:
             for _ in range(RETRY_COUNT):
                 async with session.get(url) as response:
-                    logging.info("DnF API status : {}".format(response.status))
+                    logging.info(f"DnF API status : {response.status}")
                     if response.status == 200:
                         etag = response.headers["etag"]
                         logging.debug("dnf etag: " + etag)

--- a/together_bot/models/__init__.py
+++ b/together_bot/models/__init__.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/together_bot/models/dnf_grade_channel.py
+++ b/together_bot/models/dnf_grade_channel.py
@@ -1,0 +1,26 @@
+from sqlalchemy import BigInteger, Column, Integer
+
+from together_bot.models import Base
+
+
+class DnfGradeChannel(Base):
+    __tablename__ = "dnf_grade_channel"
+
+    id = Column(Integer, primary_key=True)
+    discord_id = Column(BigInteger, unique=True)
+
+
+# 편의를 위해 만든 shortcut function임.
+# 모든 DB 접근에 대해 session을 함수로 감싸지 않아도 됨.
+def save(session, discord_id: int) -> DnfGradeChannel:
+    channel = DnfGradeChannel(discord_id=discord_id)
+    session.add(channel)
+    return channel
+
+
+def find_by_discord_id(session, discord_id: int) -> DnfGradeChannel:
+    return session.query(DnfGradeChannel).filter_by(discord_id=discord_id).one_or_none()
+
+
+def find_all(session) -> list[DnfGradeChannel]:
+    return session.query(DnfGradeChannel).all()

--- a/together_bot/models/fword_user.py
+++ b/together_bot/models/fword_user.py
@@ -1,11 +1,6 @@
 from sqlalchemy import BigInteger, Column, Integer
-from sqlalchemy.orm import declarative_base
 
-Base = declarative_base()
-
-
-def setup(engine):
-    Base.metadata.create_all(engine)
+from together_bot.models import Base
 
 
 class FwordUser(Base):

--- a/together_bot/utils/db_toolkit.py
+++ b/together_bot/utils/db_toolkit.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import sessionmaker
 
-import together_bot.models.fword_user
+from together_bot.models import Base
 
 load_dotenv()
 
@@ -18,5 +18,5 @@ def setup():
         DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+psycopg2://", 1)
 
     engine = create_engine(DATABASE_URL)
-    together_bot.models.fword_user.setup(engine)
+    Base.metadata.create_all(engine)
     Session.configure(bind=engine)


### PR DESCRIPTION
* 등급 알림 채널 목록을 DB에 저장해서 봇 재배포 후에도 알림이 끊기지 않도록 수정
* 알림 채널을 여러 개 등록할 수 있게 수정
* 알림 확인이 등록한 채널이 아닌 명령한 채널에 메세지를 보내도록 수정
* 오늘의 등급을 0시 0분에 갱신 후 저장하도록 수정
* 오늘의 등급을 확인하는 명령이 API를 매번 호출하지 않고 저장된 등급을 출력하는 걸로 수정
* 던파 서버 데이터가 실제로 바뀌었는지 etag로 확인하는 기능 추가